### PR TITLE
Potential fix for code scanning alert no. 5: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/com/freshkeeper/service/notification/FirebaseMessagingServiceImpl.kt
+++ b/app/src/main/java/com/freshkeeper/service/notification/FirebaseMessagingServiceImpl.kt
@@ -30,7 +30,7 @@ class FirebaseMessagingServiceImpl : FirebaseMessagingService() {
                 this,
                 0,
                 intent,
-                PendingIntent.FLAG_UPDATE_CURRENT,
+                PendingIntent.FLAG_IMMUTABLE,
             )
 
         val notificationBuilder =


### PR DESCRIPTION
Potential fix for [https://github.com/FreshKeeper/AndroidApp/security/code-scanning/5](https://github.com/FreshKeeper/AndroidApp/security/code-scanning/5)

To fix the problem, we need to ensure that the `PendingIntent` is immutable. This can be achieved by using the `PendingIntent.FLAG_IMMUTABLE` flag when creating the `PendingIntent`. This flag ensures that the `Intent` wrapped by the `PendingIntent` cannot be modified by other applications, thus mitigating the security risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
